### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The source code is available on github at
 [AppleDoc][3] generated documentation can be browsed at
 [http://sptim.github.io/SPTScrollViewScrubber/][4].
 
-SPTScrollViewScrubberController is also available using [Cocoapods][5]. Add 
+SPTScrollViewScrubberController is also available using [CocoaPods][5]. Add 
 this to your `Podfile` and run `pod install`:
 
 	pod 'SPTScrollViewScrubber'


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
